### PR TITLE
Implementar MCP Remoto para despliegue en Vercel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# InfluxDB connection settings
+INFLUXDB_URL=https://us-east-1-1.aws.cloud2.influxdata.com
+INFLUXDB_TOKEN=your-influxdb-token-here
+
+# Optional: Authentication for the MCP endpoint
+# MCP_AUTH_TOKEN=your-secret-token-here

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ build/
 *.log
 .env*
 .aider*
+
+# Vercel
+.vercel
+.vercel/

--- a/README-REMOTE.md
+++ b/README-REMOTE.md
@@ -1,0 +1,121 @@
+# InfluxDB MCP Server - Remote Version
+
+This is a remote version of the InfluxDB MCP (Model Context Protocol) server that can be deployed to Vercel and used with Claude AI as a remote MCP endpoint.
+
+## Features
+
+- Query InfluxDB data using Flux queries
+- Write data to InfluxDB using line protocol
+- Create organizations and buckets
+- List available resources (organizations, buckets, measurements)
+- Provides helpful prompts for Flux queries and line protocol
+
+## Deployment to Vercel
+
+### Prerequisites
+
+1. An InfluxDB instance (cloud or self-hosted)
+2. InfluxDB API token with appropriate permissions
+3. A Vercel account
+
+### Environment Variables
+
+Set the following environment variables in your Vercel project:
+
+- `INFLUXDB_URL`: Your InfluxDB instance URL (e.g., `https://us-east-1-1.aws.cloud2.influxdata.com`)
+- `INFLUXDB_TOKEN`: Your InfluxDB API token
+
+### Deploy to Vercel
+
+1. Fork this repository
+2. Connect your fork to Vercel
+3. Set the environment variables mentioned above
+4. Deploy!
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Ffrescales%2Finfluxdb-mcp-server&env=INFLUXDB_URL,INFLUXDB_TOKEN&envDescription=InfluxDB%20connection%20credentials&project-name=influxdb-mcp-server&repository-name=influxdb-mcp-server)
+
+### Using with Claude
+
+Once deployed, you can add this MCP server to Claude using:
+
+```bash
+claude mcp add --transport http influxdb https://your-project.vercel.app/api/mcp
+```
+
+Or if you need to include authentication:
+
+```bash
+claude mcp add --transport http --header "Authorization: Bearer YOUR_TOKEN" influxdb https://your-project.vercel.app/api/mcp
+```
+
+## Available Tools
+
+### write-data
+Write time-series data to InfluxDB using line protocol format.
+
+**Parameters:**
+- `org`: Organization name
+- `bucket`: Bucket name
+- `data`: Data in InfluxDB line protocol format
+- `precision`: (optional) Timestamp precision (ns, us, ms, s)
+
+### query-data
+Execute Flux queries against your InfluxDB instance.
+
+**Parameters:**
+- `org`: Organization name
+- `query`: Flux query string
+
+### create-bucket
+Create a new bucket in InfluxDB.
+
+**Parameters:**
+- `name`: Bucket name
+- `orgID`: Organization ID
+- `retentionPeriodSeconds`: (optional) Data retention period in seconds
+
+### create-org
+Create a new organization in InfluxDB.
+
+**Parameters:**
+- `name`: Organization name
+- `description`: (optional) Organization description
+
+## Available Resources
+
+- `influxdb://orgs` - List all organizations
+- `influxdb://buckets` - List all buckets
+- `influxdb://bucket/{bucketName}/measurements` - List measurements in a bucket
+- `influxdb://query/{orgName}/{fluxQuery}` - Execute a Flux query
+
+## Available Prompts
+
+- `flux-query-examples` - Get examples of common Flux queries
+- `line-protocol-guide` - Learn about InfluxDB line protocol format
+
+## Development
+
+To run locally:
+
+```bash
+npm install
+npm start
+```
+
+To test the HTTP endpoint locally:
+
+```bash
+npm install
+vercel dev
+```
+
+## Security Considerations
+
+- Always use HTTPS when deploying to production
+- Consider implementing authentication if exposing sensitive data
+- Use environment variables for all credentials
+- Implement rate limiting if necessary
+
+## License
+
+MIT

--- a/api/mcp.js
+++ b/api/mcp.js
@@ -1,4 +1,4 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { HttpServerTransport } from "../src/transports/http.js";
 import { z } from "zod";
 

--- a/api/mcp.js
+++ b/api/mcp.js
@@ -1,0 +1,159 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { HttpServerTransport } from "../src/transports/http.js";
+import { z } from "zod";
+
+// Import config
+import { validateEnvironment } from "../src/config/env.js";
+
+// Import utilities
+import { configureLogger } from "../src/utils/loggerConfig.js";
+
+// Import resource handlers
+import { listOrganizations } from "../src/handlers/organizationsHandler.js";
+import { listBuckets } from "../src/handlers/bucketsHandler.js";
+import { bucketMeasurements } from "../src/handlers/measurementsHandler.js";
+import { executeQuery } from "../src/handlers/queryHandler.js";
+
+// Import tool handlers
+import { writeData } from "../src/handlers/writeDataTool.js";
+import { queryData } from "../src/handlers/queryDataTool.js";
+import { createBucket } from "../src/handlers/createBucketTool.js";
+import { createOrg } from "../src/handlers/createOrgTool.js";
+
+// Import prompt handlers
+import { fluxQueryExamplesPrompt } from "../src/prompts/fluxQueryExamplesPrompt.js";
+import { lineProtocolGuidePrompt } from "../src/prompts/lineProtocolGuidePrompt.js";
+
+// Configure logger and validate environment
+configureLogger();
+
+// Create MCP server instance (singleton)
+let server;
+
+function getServer() {
+  if (!server) {
+    server = new McpServer({
+      name: "InfluxDB",
+      version: "0.1.1",
+    });
+
+    // Register resources
+    server.resource("orgs", "influxdb://orgs", listOrganizations);
+    server.resource("buckets", "influxdb://buckets", listBuckets);
+    server.resource(
+      "bucket-measurements",
+      new ResourceTemplate("influxdb://bucket/{bucketName}/measurements", {
+        list: undefined,
+      }),
+      bucketMeasurements,
+    );
+    server.resource(
+      "query",
+      new ResourceTemplate("influxdb://query/{orgName}/{fluxQuery}", {
+        list: undefined,
+      }),
+      executeQuery,
+    );
+
+    // Register tools
+    server.tool(
+      "write-data",
+      {
+        org: z.string().describe("The organization name"),
+        bucket: z.string().describe("The bucket name"),
+        data: z.string().describe("Data in InfluxDB line protocol format"),
+        precision: z.enum(["ns", "us", "ms", "s"]).optional().describe(
+          "Timestamp precision (ns, us, ms, s)",
+        ),
+      },
+      writeData,
+    );
+
+    server.tool(
+      "query-data",
+      {
+        org: z.string().describe("The organization name"),
+        query: z.string().describe("Flux query string"),
+      },
+      queryData,
+    );
+
+    server.tool(
+      "create-bucket",
+      {
+        name: z.string().describe("The bucket name"),
+        orgID: z.string().describe("The organization ID"),
+        retentionPeriodSeconds: z.number().optional().describe(
+          "Retention period in seconds (optional)",
+        ),
+      },
+      createBucket,
+    );
+
+    server.tool(
+      "create-org",
+      {
+        name: z.string().describe("The organization name"),
+        description: z.string().optional().describe(
+          "Organization description (optional)",
+        ),
+      },
+      createOrg,
+    );
+
+    // Register prompts
+    server.prompt("flux-query-examples", {}, fluxQueryExamplesPrompt);
+    server.prompt("line-protocol-guide", {}, lineProtocolGuidePrompt);
+  }
+  
+  return server;
+}
+
+// Vercel serverless function handler
+export default async function handler(req, res) {
+  // Only allow POST requests
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  // Set CORS headers if needed
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+
+  // Handle OPTIONS request for CORS
+  if (req.method === 'OPTIONS') {
+    return res.status(200).end();
+  }
+
+  try {
+    // Validate environment on each request
+    validateEnvironment();
+
+    // Get or create the server instance
+    const mcpServer = getServer();
+    
+    // Create HTTP transport for this request
+    const transport = new HttpServerTransport(req, res);
+    
+    // Connect the server to the transport
+    await mcpServer.connect(transport);
+    
+    // The transport will handle the response
+  } catch (error) {
+    console.error('MCP Server Error:', error);
+    
+    // Send error response if not already sent
+    if (!res.headersSent) {
+      res.status(500).json({
+        jsonrpc: "2.0",
+        error: {
+          code: -32603,
+          message: "Internal error",
+          data: error.message
+        }
+      });
+    }
+  }
+}

--- a/src/transports/http.js
+++ b/src/transports/http.js
@@ -1,0 +1,56 @@
+/**
+ * HTTP Server Transport for MCP
+ * 
+ * This transport allows the MCP server to communicate over HTTP,
+ * enabling deployment as a remote server (e.g., on Vercel).
+ */
+
+export class HttpServerTransport {
+  constructor(req, res) {
+    this.req = req;
+    this.res = res;
+    this.responsesSent = false;
+  }
+
+  async start() {
+    // Process the incoming request
+    const requestBody = this.req.body;
+    
+    if (!requestBody || typeof requestBody !== 'object') {
+      throw new Error('Invalid request body');
+    }
+
+    // The request body should be a JSON-RPC message
+    if (!requestBody.jsonrpc || requestBody.jsonrpc !== '2.0') {
+      throw new Error('Invalid JSON-RPC version');
+    }
+
+    // Emit the message to be processed by the server
+    if (this.onmessage) {
+      await this.onmessage(requestBody);
+    }
+  }
+
+  async send(message) {
+    // Send the response back to the client
+    if (!this.responsesSent && !this.res.headersSent) {
+      this.responsesSent = true;
+      
+      // For streaming responses, we could implement chunked transfer
+      // For now, we'll send complete responses
+      this.res.status(200).json(message);
+    }
+  }
+
+  async close() {
+    // Ensure the response is sent if not already
+    if (!this.responsesSent && !this.res.headersSent) {
+      this.res.status(200).end();
+    }
+  }
+
+  // Event handlers - these will be set by the MCP server
+  onmessage = null;
+  onclose = null;
+  onerror = null;
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,13 @@
+{
+  "functions": {
+    "api/mcp.js": {
+      "maxDuration": 30
+    }
+  },
+  "rewrites": [
+    {
+      "source": "/mcp",
+      "destination": "/api/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
## Implementación de MCP Remoto para Vercel

Este PR agrega la funcionalidad necesaria para ejecutar el servidor MCP de InfluxDB como un servidor remoto en Vercel.

### Cambios realizados:

1. **Nuevo endpoint HTTP** (`api/mcp.js`):
   - Maneja las solicitudes JSON-RPC del protocolo MCP
   - Implementa un patrón singleton para el servidor MCP
   - Incluye manejo de CORS para permitir acceso desde Claude

2. **Transporte HTTP** (`src/transports/http.js`):
   - Nueva implementación de transporte compatible con el SDK de MCP
   - Maneja la comunicación HTTP bidireccional
   - Gestiona correctamente los mensajes JSON-RPC

3. **Configuración de Vercel** (`vercel.json`):
   - Configura el tiempo máximo de ejecución (30 segundos)
   - Añade rewrite para acceder al endpoint como `/mcp`

4. **Documentación** (`README-REMOTE.md`):
   - Instrucciones completas para el despliegue en Vercel
   - Guía de uso con Claude AI
   - Descripción de todas las herramientas y recursos disponibles

5. **Archivos de soporte**:
   - `.env.example`: Ejemplo de variables de entorno necesarias
   - `.gitignore`: Actualizado para incluir archivos de Vercel

### Cómo usar:

1. Despliega en Vercel usando el botón en el README
2. Configura las variables de entorno `INFLUXDB_URL` y `INFLUXDB_TOKEN`
3. Añade el servidor a Claude con:
   ```bash
   claude mcp add --transport http influxdb https://tu-proyecto.vercel.app/api/mcp
   ```

### Próximos pasos:

- Probar el despliegue en Vercel
- Verificar la conexión con Claude
- Considerar añadir autenticación opcional para mayor seguridad