### PR TITLE
🔧 Fix: Correcciones críticas para Vercel deployment

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -1,0 +1,13 @@
+// Simple health check endpoint
+export default function handler(req, res) {
+  res.status(200).json({ 
+    status: 'ok',
+    message: 'InfluxDB MCP Server is running',
+    endpoint: '/api/mcp',
+    method: 'POST only',
+    env: {
+      hasToken: !!process.env.INFLUXDB_TOKEN,
+      hasUrl: !!process.env.INFLUXDB_URL
+    }
+  });
+}

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -6,7 +6,9 @@ export const DEFAULT_ORG = process.env.INFLUXDB_ORG;
 // Check required environment variables
 export function validateEnvironment() {
   if (!INFLUXDB_TOKEN) {
-    console.error("Error: INFLUXDB_TOKEN environment variable is required");
-    process.exit(1);
+    throw new Error("INFLUXDB_TOKEN environment variable is required");
+  }
+  if (!INFLUXDB_URL) {
+    throw new Error("INFLUXDB_URL environment variable is required");
   }
 }

--- a/src/utils/loggerConfig.js
+++ b/src/utils/loggerConfig.js
@@ -1,9 +1,14 @@
-// Redirect console.log and console.error to stderr to avoid interfering with MCP protocol messages
-// MCP uses stdout for protocol communication
-const originalConsoleLog = console.log;
-const originalConsoleError = console.error;
+// Logger configuration for different environments
+const isVercel = process.env.VERCEL || process.env.VERCEL_ENV;
 
 export function configureLogger() {
+  // In Vercel/serverless environments, keep standard console behavior
+  if (isVercel) {
+    // console.log and console.error work normally in Vercel
+    return;
+  }
+  
+  // For local MCP server (stdio transport), redirect to stderr
   console.log = function() {
     process.stderr.write("[INFO] " + Array.from(arguments).join(" ") + "\n");
   };


### PR DESCRIPTION
## Correcciones críticas para el despliegue en Vercel

Este PR corrige problemas que impiden que el servidor MCP funcione correctamente en Vercel:

### Cambios:

1. **Fix en `src/config/env.js`**:
   - Cambiado `process.exit(1)` por `throw new Error()` para entornos serverless
   - Vercel no maneja bien `process.exit()` en funciones serverless

2. **Fix en `src/utils/loggerConfig.js`**:
   - Detecta el entorno de Vercel y mantiene el comportamiento estándar de console
   - Evita escribir a `stderr` en Vercel que puede causar problemas

3. **Nuevo endpoint de health check** (`api/health.js`):
   - Permite verificar que el servidor está funcionando
   - Muestra si las variables de entorno están configuradas

### Para probar:

Después del merge y redeploy automático:
1. Visita: https://influxdb-mcp-server.vercel.app/api/health
2. Deberías ver el estado del servidor y las variables de entorno

Estos cambios son esenciales para que el servidor MCP funcione en Vercel.