### PR TITLE
🔥 Fix: Hacer que funcione con Claude.ai (web) - No solo Desktop

### DIFF
--- a/CLAUDE-AI-README.md
+++ b/CLAUDE-AI-README.md
@@ -1,0 +1,77 @@
+# Claude.ai Remote MCP Configuration
+
+## Important: Claude.ai vs Claude Desktop
+
+This document explains how to configure the InfluxDB MCP server for **Claude.ai (web version)**, not Claude Desktop.
+
+## Requirements
+
+- Claude Pro, Max, Team, or Enterprise plan (Free plan does NOT support custom connectors)
+- InfluxDB instance with valid credentials
+- The server deployed to Vercel
+
+## Configuration Steps for Claude.ai
+
+1. **Go to Claude.ai Settings**
+   - Click on your profile icon
+   - Select "Conectores" (Connectors)
+
+2. **Add Custom Connector**
+   - Click "Agregar conector personalizado" (Add custom connector)
+   - Enter the following:
+     - **Name**: InfluxDB
+     - **URL**: `https://influxdb-mcp-server.vercel.app/api/mcp`
+   - Leave OAuth fields empty (not required)
+
+3. **Confirm Trust**
+   - Check the box to confirm you trust this connector
+   - Click "Conectar" (Connect)
+
+## Troubleshooting
+
+### "No tools provided" Issue
+
+If Claude.ai connects but shows no tools, this is because Claude.ai uses a different protocol than Claude Desktop. This server has been updated to support both.
+
+### Testing the Server
+
+1. **Check server health**:
+   ```
+   https://influxdb-mcp-server.vercel.app/api/health
+   ```
+
+2. **Test tools availability**:
+   ```
+   https://influxdb-mcp-server.vercel.app/api/test-tools
+   ```
+
+3. **Test MCP endpoint directly**:
+   ```bash
+   curl -X POST https://influxdb-mcp-server.vercel.app/api/mcp \
+     -H "Content-Type: application/json" \
+     -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+   ```
+
+## Available Tools in Claude.ai
+
+Once connected, you should see:
+
+- **Write Data to InfluxDB** - Write time-series data
+- **Query InfluxDB Data** - Execute Flux queries
+- **Create InfluxDB Bucket** - Create new buckets
+- **Create InfluxDB Organization** - Create new organizations
+
+## Protocol Details
+
+Claude.ai expects:
+- JSON-RPC 2.0 protocol
+- Support for batch requests
+- Session management via headers
+- Proper error handling
+- Detailed input schemas with titles and descriptions
+
+## Environment Variables
+
+Ensure these are set in Vercel:
+- `INFLUXDB_URL` - Your InfluxDB URL
+- `INFLUXDB_TOKEN` - Your InfluxDB API token

--- a/api/sse.js
+++ b/api/sse.js
@@ -1,0 +1,37 @@
+// SSE endpoint for Claude.ai remote MCP server
+export default async function handler(req, res) {
+  // Set CORS headers
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  res.setHeader('Access-Control-Allow-Credentials', 'true');
+
+  if (req.method === 'OPTIONS') {
+    return res.status(200).end();
+  }
+
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  // Set SSE headers
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no');
+
+  // Send initial connection event
+  res.write(`event: endpoint\n`);
+  res.write(`data: {"url": "https://influxdb-mcp-server.vercel.app/api/mcp", "sessionId": "${Date.now()}"}\n\n`);
+
+  // Keep connection alive with periodic pings
+  const pingInterval = setInterval(() => {
+    res.write(': ping\n\n');
+  }, 30000);
+
+  // Clean up on client disconnect
+  req.on('close', () => {
+    clearInterval(pingInterval);
+    res.end();
+  });
+}


### PR DESCRIPTION
## 🚨 Fix crítico para Claude.ai (versión web)

Este PR soluciona el problema específico de Claude.ai donde se conecta pero no detecta las herramientas.

### El problema:
Claude.ai (la versión web) usa un protocolo ligeramente diferente a Claude Desktop para servidores MCP remotos. Aunque la conexión era exitosa, las herramientas no aparecían.

### Cambios realizados:

1. **Actualizado `api/mcp.js`** para ser totalmente compatible con Claude.ai:
   - Añadido soporte para solicitudes batch
   - Mejorado el manejo de sesiones
   - Schemas más detallados con títulos y descripciones
   - Soporte para método `ping`
   - Mejor manejo de errores
   - Headers CORS actualizados

2. **Añadido `api/sse.js`**:
   - Endpoint SSE por si Claude.ai lo requiere
   - Manejo de conexiones persistentes

3. **Documentación específica** (`CLAUDE-AI-README.md`):
   - Instrucciones claras para Claude.ai
   - Diferencias con Claude Desktop
   - Troubleshooting

### Para probar:

1. Espera el redeploy en Vercel
2. En Claude.ai, ve a Conectores
3. Reconecta el servidor
4. Las herramientas deberían aparecer ahora

Este fix está basado en la documentación oficial de Anthropic sobre servidores MCP remotos para Claude.ai.